### PR TITLE
docs: add layered AGENTS.md for repo and core modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# Ra3MapUtils Agent 协作规范（仓库级）
+
+## 1) 适用范围与优先级
+- 本文件适用于整个仓库：`N:\workspace\ra3\Ra3MapUtils`。
+- 子目录存在 `AGENTS.md` 时，子目录规则优先于本文件：
+  - `Ra3MapUtils/AGENTS.md`
+  - `SharedFunctionLib/AGENTS.md`
+  - `UtilCoreLib/AGENTS.md`
+- 若规则冲突，优先级：更具体目录 > 更上层目录。
+
+## 2) 仓库职责地图
+- 主干模块（生产功能）：
+  - `Ra3MapUtils`：WPF 主程序（MVVM）、内嵌 HTTP API、MCP 工具、插件与微程序管理。
+  - `SharedFunctionLib`：业务层与 DAO，配置/元数据持久化（SQLite + linq2db）。
+  - `UtilCoreLib`：地图文件/脚本/map.str/XML 等底层工具。
+  - `KnowledgeBaseLib`、`KnowledgeBaseCli`：知识库（SQLite FTS）与 CLI。
+- 实验/兼容目录（默认非主改动路径）：
+  - `test_field`：实验性样例与手工测试代码。
+  - `WBLegacy`：legacy 兼容工程。
+- 文档与打包：
+  - `doc`：发布说明与截图。
+  - `dev_tools`：打包/元数据脚本。
+
+## 3) 通用工作流（必须）
+1. 先定位改动层级：`View/ViewModel -> Service -> Business -> DAO -> 数据`。
+2. 先读现有实现，再做最小改动；禁止跨层“顺手重构”。
+3. 有接口改动时保持链路一致：接口声明、实现、DI 注册、调用点同步更新。
+4. 先做最小验证，再补充必要说明（风险、兼容性、未验证项）。
+
+## 4) 命令矩阵（以可执行为准）
+- 推荐优先按项目构建，不直接依赖 `sln` 全量构建：
+  - `dotnet build KnowledgeBaseLib\KnowledgeBaseLib.csproj`
+  - `dotnet build KnowledgeBaseCli\KnowledgeBaseCli.csproj`
+  - `dotnet build UtilCoreLib\UtilCoreLib.csproj --no-restore`
+  - `dotnet build SharedFunctionLib\SharedFunctionLib.csproj --no-restore`
+- 主程序构建：
+  - `dotnet build Ra3MapUtils\Ra3MapUtils.csproj --no-restore`
+  - 已知会出现较多 `NU190x`（漏洞审计）与 `NU1701`（兼容）噪音；请在结论中明确“是否为新引入问题”。
+- 运行主程序：
+  - `dotnet run --project Ra3MapUtils\Ra3MapUtils.csproj`
+- 打包（需本机前置）：
+  - `dev_tools\package.ps1`（依赖 `vpk`、`7z`）
+  - `dev_tools\package_lualib.ps1`（依赖本机 Lua 库目录与 `7z`）
+
+## 5) 编码与文本规则
+- 仓库含大量中文文本，统一按 UTF-8 处理。
+- PowerShell 读取文本时显式使用：`Get-Content -Encoding UTF8`。
+- 文档与 JSON 修改后需确认无乱码、无错误转义。
+
+## 6) Do / Don't
+- Do：
+  - 仅修改与当前任务直接相关的模块。
+  - 保持模块边界清晰（UI 不直接写 DAO）。
+  - 在提交说明中标注验证命令和结果。
+- Don't：
+  - 不在未确认影响面的情况下改动 `test_field` / `WBLegacy`。
+  - 不把实验代码混入主流程目录。
+  - 不在未说明风险时更改持久化表结构或关键路径（启动、插件安装、地图文件操作）。
+
+## 7) 子模块入口
+- 改主应用（页面、API、MCP、插件/微程序）前先读：`Ra3MapUtils/AGENTS.md`
+- 改业务/DAO/配置存储前先读：`SharedFunctionLib/AGENTS.md`
+- 改地图底层工具前先读：`UtilCoreLib/AGENTS.md`
+

--- a/Ra3MapUtils/AGENTS.md
+++ b/Ra3MapUtils/AGENTS.md
@@ -1,0 +1,56 @@
+# Ra3MapUtils 子模块 Agent 规范
+
+## 1) 适用范围
+- 本文件适用于 `Ra3MapUtils/` 目录及其子目录。
+- 若与仓库根 `AGENTS.md` 冲突，以本文件为准。
+
+## 2) 模块定位
+- `Views/` + `ViewModels/`：WPF MVVM UI 层。
+- `Services/Interface` + `Services/Impl`：服务抽象与实现。
+- `API/`：内嵌 HTTP API 控制器（`ApiResponse<T>` 返回约定）。
+- `MCP/`：MCP 工具（`[McpServerToolType]` / `[McpServerTool]`）。
+- `data/plugins` + `data/nano_programs`：插件与微程序资源。
+- `App.xaml.cs`：DI 注册、Web 服务启动、单实例控制关键入口。
+
+## 3) 必须遵守的改动规则
+- MVVM 改动：
+  - 页面行为改动需同步检查对应 `View` 与 `ViewModel`。
+  - 命令优先使用 `RelayCommand`；可观察属性优先 `ObservableProperty`。
+- Service 改动：
+  - 新能力先定义接口，再落实现；最后在 `App.ConfigureServices()` 注册。
+  - 禁止在 ViewModel 直接跳过 Service 访问底层 DAO。
+- API 改动：
+  - 路由统一放在控制器 `[Route("api/...")]` 下。
+  - 统一返回 `ApiResponse<T>`，失败分支要给出可诊断信息。
+- MCP 改动：
+  - 工具类必须保留 `[McpServerToolType]`。
+  - 工具方法必须标注 `[McpServerTool]` 并补充说明。
+- 插件/微程序改动：
+  - 插件目录遵循 `plugin_meta.json` + `Main.cs` + `readme.txt`。
+  - 微程序目录遵循 `info.json` + `Main.cs`。
+  - 若涉及输出资源，保持 `.csproj` 中 CopyToOutput 规则一致。
+
+## 4) 高风险区域（先确认后改）
+- `App.xaml.cs`：
+  - 单实例 `Mutex`、Web 启动（`127.0.0.1:30033`）、Swagger、MCP 映射（`/mcp`）。
+- `Services/Impl/NewWorldBuilderPluginService.cs`：
+  - 插件安装流程会复制/覆盖目标目录文件。
+- `Utils/MapLuaImporterUtil.cs`：
+  - 直接影响地图脚本内容与保存行为。
+
+## 5) 快速验证清单
+1. 结构验证：接口、实现、DI 注册、调用点是否齐全。  
+2. 构建验证：`dotnet build Ra3MapUtils\Ra3MapUtils.csproj --no-restore`。  
+3. 路由/工具验证（按需）：
+   - `rg "\[Route\(|\[Http(Get|Post|Put|Delete)" API`
+   - `rg "\[McpServerToolType\]|\[McpServerTool\]" MCP`
+4. 若构建输出含 `NU190x`/`NU1701` 噪音，在结论中标注“是否新增”。
+
+## 6) Do / Don't
+- Do：
+  - 保持 UI -> Service -> Business/DAO 调用链条清晰。
+  - 修改端点时同步更新文档注释（XML 注释/说明文本）。
+- Don't：
+  - 不破坏 `App.xaml.cs` 启动顺序。
+  - 不将 `data/nano_programs/*/Main.cs` 纳入主工程编译源文件。
+

--- a/SharedFunctionLib/AGENTS.md
+++ b/SharedFunctionLib/AGENTS.md
@@ -1,0 +1,46 @@
+# SharedFunctionLib 子模块 Agent 规范
+
+## 1) 适用范围
+- 本文件适用于 `SharedFunctionLib/` 目录。
+- 本模块目标框架为 `.NET Framework 4.5`，兼容性优先。
+
+## 2) 模块职责
+- `Business/`：面向上层的业务门面（配置、插件、微程序元数据等）。
+- `DAO/`：SQLite 持久化访问（linq2db + SQL）。
+- `Models/`：持久化模型与轻量数据结构。
+- `Utils/`：路径与连接封装（`Ra3MapUtilsPathUtil`、`SqliteConnection`）。
+
+## 3) 必须遵守的改动规则
+- 兼容性：
+  - 禁止引入仅 `net6+/net8+` 才有的 API 或语法依赖。
+  - 引用新增包前确认可用于 `net45`。
+- DAO 规则：
+  - DAO 入口方法保持 `InitDB()` 保护逻辑。
+  - 增改表结构时必须提供升级路径（例如 `Upgrade()` 分支），不能只改建表 SQL。
+  - 新增数据表/模型后，记得在 `Utils/SqliteConnection.cs` 中补充映射表属性。
+- 配置键规则：
+  - `SettingsDAO` 键名使用模块前缀（示例：`LuaImporter_*`、`Update_*`、`ApiService_*`）。
+  - 改键名时必须考虑历史数据兼容读取。
+
+## 4) 与主应用耦合点
+- 路径与数据库：
+  - `%AppData%/Ra3MapUtils` 下的 `Ra3MapUtils.db` 由 `Ra3MapUtilsPathUtil` 管理。
+- 上层依赖：
+  - `Ra3MapUtils` 中多个 Service 直接调用 `Business` 层静态方法。
+  - 任何 `Business` 返回结构变更都可能影响 ViewModel/UI 展示。
+
+## 5) 快速验证清单
+1. 构建验证（建议增量）：`dotnet build SharedFunctionLib\SharedFunctionLib.csproj --no-restore`  
+2. 依赖验证（如涉及）：`dotnet build UtilCoreLib\UtilCoreLib.csproj --no-restore`  
+3. DAO 变更验证：
+   - 检查 `InitDB/Upgrade` 是否覆盖新增列或索引。
+   - 检查新增模型是否已接入 `SqliteConnection`。
+
+## 6) Do / Don't
+- Do：
+  - 保持 `Business -> DAO -> DB` 分层职责单一。
+  - 在数据库相关改动中记录兼容策略。
+- Don't：
+  - 不把 UI 逻辑塞进 `Business`/`DAO`。
+  - 不做无升级策略的表结构破坏性变更。
+

--- a/UtilCoreLib/AGENTS.md
+++ b/UtilCoreLib/AGENTS.md
@@ -1,0 +1,47 @@
+# UtilCoreLib 子模块 Agent 规范
+
+## 1) 适用范围
+- 本文件适用于 `UtilCoreLib/` 目录。
+- 本模块是地图底层工具库，很多方法有直接文件系统副作用。
+
+## 2) 模块职责
+- `mapFileHelper/`：地图目录识别、复制、重命名、删除、压缩、列举。
+- `mapScriptHelper/`：脚本组与脚本构造辅助。
+- `mapstrFileHelper/`：`map.str` 相关处理。
+- `mapXmlOperator/`：地图 XML 数据处理。
+- `utils/`：日志、文件、XML 辅助函数。
+
+## 3) 必须遵守的改动规则
+- 文件操作安全：
+  - 涉及地图目录参数时，先走 `MapFileHelper.TranslateMapPath` 规范化。
+  - 删除/移动/压缩前必须确认目标是合法地图目录（`.map` 核心文件存在）。
+  - 对“批量操作地图文件”改动时必须显式考虑异常回滚或失败提示。
+- 兼容性：
+  - 本模块目标 `net45`，禁止引入高版本专属 API。
+  - 保持对 `MapCoreLib` 相关类型与调用方式兼容。
+- 副作用意识：
+  - `Copy/Move/Del` 会真实改动地图目录，不允许“先删后验”式实现。
+  - 变更日志输出时保持 `Logger` 语义稳定，避免吞掉关键错误信息。
+
+## 4) 与上层耦合点
+- `SharedFunctionLib` 与 `Ra3MapUtils` 都会调用本模块能力。
+- 一旦改动路径解析或地图判定逻辑，会联动影响：
+  - 地图管理页（复制/重命名/删除）
+  - 插件联动与脚本导入相关流程
+
+## 5) 快速验证清单
+1. 构建验证：`dotnet build UtilCoreLib\UtilCoreLib.csproj --no-restore`  
+2. 关键函数走读（至少）：
+   - `TranslateMapPath`
+   - `IsMap`
+   - `Copy/Move/Del`
+3. 风险复核：确认不存在“路径未规范化即执行文件操作”的新路径。
+
+## 6) Do / Don't
+- Do：
+  - 优先做保守改动，确保地图文件安全。
+  - 明确异常信息，便于上层 UI 提示用户。
+- Don't：
+  - 不在不校验地图合法性的情况下执行删除或覆盖。
+  - 不把模块改造成依赖 UI 或主程序运行时状态。
+


### PR DESCRIPTION
## Summary
- add repository-level `AGENTS.md`
- add module-level `AGENTS.md` for:
  - `Ra3MapUtils/`
  - `SharedFunctionLib/`
  - `UtilCoreLib/`

## Details
- define rule priority (root vs submodule)
- document architecture boundaries and execution workflow
- add command matrix and known build-noise notes (`NU190x`/`NU1701`)
- add UTF-8 handling guidance for Chinese text files
- add strict Do/Don't, risk boundaries, and verification checklists

## Scope
- documentation-only change
- no code/interface/API behavior changes
